### PR TITLE
Fixing the problem with using the request from the outer context

### DIFF
--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/BaseHandlerStd.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/BaseHandlerStd.java
@@ -130,7 +130,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         GetReplicationSetRequest awsRequest = Translator.translateToReadRequest(progress.getResourceModel());
         GetReplicationSetResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
             awsRequest,
-            req -> proxyClient.client().getReplicationSet(req)
+            proxyClient.client()::getReplicationSet
         );
         ReplicationSetStatus status = awsResponse.replicationSet().status();
         logger.log("waitForReplicationSetToBecomeActive: replicationSet status = " + status.name());
@@ -209,7 +209,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       }
       UpdateDeletionProtectionResponse res = client.injectCredentialsAndInvokeV2(
           awsRequest,
-          req -> client.client().updateDeletionProtection(awsRequest)
+          client.client()::updateDeletionProtection
       );
       logger.log("callUpdateDeletionProtection: updateDeletionProtection call was successful");
       return res;

--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/CreateHandler.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/CreateHandler.java
@@ -97,7 +97,7 @@ public class CreateHandler extends BaseHandlerStd {
       try {
         ListReplicationSetsResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
             ListReplicationSetsRequest.builder().build(),
-            req -> proxyClient.client().listReplicationSets(req)
+            proxyClient.client()::listReplicationSets
         );
         if ((awsResponse.replicationSetArns() != null) && !awsResponse.replicationSetArns().isEmpty()) {
           return ProgressEvent.defaultFailureHandler(new RuntimeException("Replication set " +
@@ -117,7 +117,7 @@ public class CreateHandler extends BaseHandlerStd {
       CreateReplicationSetResponse awsResponse;
       awsResponse = client.injectCredentialsAndInvokeV2(
           awsRequest,
-          req -> client.client().createReplicationSet(req)
+          client.client()::createReplicationSet
       );
       logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
       return awsResponse;

--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/DeleteHandler.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/DeleteHandler.java
@@ -84,6 +84,6 @@ public class DeleteHandler extends BaseHandlerStd {
   }
 
   private BiFunction<DeleteReplicationSetRequest, ProxyClient<SsmIncidentsClient>, DeleteReplicationSetResponse> callDeleteReplicationSet() {
-    return (request, client) -> client.injectCredentialsAndInvokeV2(request, req -> client.client().deleteReplicationSet(req));
+    return (request, client) -> client.injectCredentialsAndInvokeV2(request, client.client()::deleteReplicationSet);
   }
 }

--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/ListHandler.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/ListHandler.java
@@ -26,7 +26,7 @@ public class ListHandler extends BaseHandlerStd {
     try {
       ListReplicationSetsResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
           ListReplicationSetsRequest.builder().build(),
-          req -> proxyClient.client().listReplicationSets(req)
+          proxyClient.client()::listReplicationSets
       );
 
       ImmutableList.Builder<ResourceModel> modelsBuilder = ImmutableList.builder();

--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/ReadHandler.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/ReadHandler.java
@@ -46,7 +46,7 @@ public class ReadHandler extends BaseHandlerStd {
     try {
       GetReplicationSetResponse awsResponse = proxyClient.injectCredentialsAndInvokeV2(
           awsRequest,
-          req -> proxyClient.client().getReplicationSet(req)
+          proxyClient.client()::getReplicationSet
       );
       Set<ReplicationRegion> replicationRegions = awsResponse.replicationSet().regionMap().entrySet().stream().map(
           regionConfig ->

--- a/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/UpdateHandler.java
+++ b/aws-ssmincidents-replicationset/src/main/java/software/amazon/ssmincidents/replicationset/UpdateHandler.java
@@ -66,7 +66,7 @@ public class UpdateHandler extends BaseHandlerStd {
               if (!progress.getCallbackContext().mainAPICalled()) {
                 GetReplicationSetResponse currentReplicationSet = proxyClient.injectCredentialsAndInvokeV2(
                     Translator.translateToReadRequest(model),
-                    req -> proxyClient.client().getReplicationSet(req)
+                    proxyClient.client()::getReplicationSet
                 );
                 return Translator.translateToUpdateRequest(currentReplicationSet.replicationSet(), model, clientToken);
               } else {
@@ -101,7 +101,7 @@ public class UpdateHandler extends BaseHandlerStd {
       UpdateReplicationSetResponse awsResponse =
           client.injectCredentialsAndInvokeV2(
               awsRequest,
-              req -> client.client().updateReplicationSet(req)
+              client.client()::updateReplicationSet
           );
       logger.log(String.format("%s update has initiated successfully", ResourceModel.TYPE_NAME));
       return awsResponse;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ssm-incidents/issues/10

*Description of changes:*
Fixing the AWS Request source when calling UpdateDeletionProtection.
Updating other places in the code to avoid similar issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
